### PR TITLE
Cache Connection Pool and filter stabilization

### DIFF
--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use sqlx::error::Error;
 use sqlx::postgres::PgRow;
 use sqlx::{Postgres, Row};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use tiktoken_rs::cl100k_base;
 pub const VECTORIZE_SCHEMA: &str = "vectorize";
 static TRIGGER_FN_PREFIX: &str = "vectorize.handle_update_";
@@ -560,7 +560,7 @@ pub fn hybrid_search_query(
     rrf_k: f32,
     semantic_weight: f32,
     fts_weight: f32,
-    filters: &HashMap<String, FilterValue>,
+    filters: &BTreeMap<String, FilterValue>,
 ) -> String {
     let cols = &return_columns
         .iter()

--- a/server/sql/example.sql
+++ b/server/sql/example.sql
@@ -48,4 +48,4 @@ INSERT INTO my_products(product_id, product_name, description, product_category,
 (38, 'Jigsaw Puzzle', 'Picture printed on cardboard or wood and cut into pieces to be reassembled', 'toys', 12.99, NOW()),
 (39, 'Hammock', 'Sling made of fabric or netting, suspended between two points for relaxation', 'outdoor', 40.00, NOW()),
 (40, 'Luggage Tag', 'Accessory attached to luggage for identification purposes', 'travel', 7.50, NOW())
-;
+ON CONFLICT (product_id) DO NOTHING;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -29,6 +29,13 @@ async fn main() {
         .connect(&cfg.database_url)
         .await
         .expect("unable to connect to postgres");
+    
+    // Create a separate connection pool for cache refresher
+    let cache_pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&cfg.database_url)
+        .await
+        .expect("unable to connect to postgres for cache refresher");
     let server_port = cfg.webserver_port;
     let server_workers = cfg.num_server_workers;
     init::init_project(&pool, Some(&cfg.database_url))
@@ -49,9 +56,10 @@ async fn main() {
     let proxy_pool = pool.clone();
     let proxy_cfg = cfg.clone();
     let proxy_jobmap = Arc::clone(&jobmap);
+    let proxy_cache_pool = cache_pool.clone();
     if cfg.proxy_enabled {
         tokio::spawn(async move {
-            if let Err(e) = start_postgres_proxy(proxy_cfg, proxy_pool, proxy_jobmap).await {
+            if let Err(e) = start_postgres_proxy(proxy_cfg, proxy_pool, proxy_jobmap, proxy_cache_pool).await {
                 error!("Failed to start PostgreSQL proxy: {e}");
             }
         });
@@ -97,6 +105,7 @@ async fn start_postgres_proxy(
     cfg: Config,
     pool: sqlx::PgPool,
     jobmap: Arc<RwLock<HashMap<String, VectorizeJob>>>,
+    cache_pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bind_address = "0.0.0.0";
     let timeout = 30;
@@ -116,15 +125,23 @@ async fn start_postgres_proxy(
     let config = Arc::new(ProxyConfig {
         postgres_addr,
         timeout: Duration::from_secs(timeout),
-        jobmap,
+        jobmap: Arc::clone(&jobmap),
         db_pool: pool.clone(),
+        prepared_statements: Arc::new(RwLock::new(HashMap::new())),
+    });
+
+    // Create a separate config for cache sync listener with its own connection pool
+    let config_for_sync = Arc::new(ProxyConfig {
+        postgres_addr,
+        timeout: Duration::from_secs(timeout),
+        jobmap: Arc::clone(&jobmap),
+        db_pool: cache_pool.clone(),
         prepared_statements: Arc::new(RwLock::new(HashMap::new())),
     });
 
     info!("Proxy listening on: {listen_addr}");
     info!("Forwarding to PostgreSQL at: {postgres_addr}");
 
-    let config_for_sync = Arc::clone(&config);
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(1)).await;
         if let Err(e) = start_cache_sync_listener(config_for_sync).await {

--- a/server/src/routes/search.rs
+++ b/server/src/routes/search.rs
@@ -85,7 +85,6 @@ pub async fn search(
 
     // check inputs and filters are valid if they exist and create a SQL string for them
     query::check_input(&payload.job_name)?;
-    query::check_input(&payload.query)?;
     if !payload.filters.is_empty() {
         for (key, value) in &payload.filters {
             // validate key and value


### PR DESCRIPTION
- give job cache updater its own connection pool
- use BTree instead of HashMap for consistent order of filters