### PR TITLE
Worker refactors

### DIFF
--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -50,18 +50,17 @@ jobs:
       - name: Install project dependencies
         run: |
           make setup
-          cargo install pg-trunk
       - name: Test previous version (v0.20.0)
         env:
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CO_API_KEY: ${{ secrets.CO_API_KEY }}
         run: |
-          trunk install vectorize --version 0.20.0 --pg-config $(cargo pgrx info pg-config pg17)
           git fetch --tags
           git checkout tags/v0.20.0
           # pgrx=0.12.5 required for v0.20.0
           cargo install cargo-pgrx --version 0.12.5 --locked
+          cargo pgrx install --pg-config $(cargo pgrx info pg-config pg17)
           # use integration tests for v0.20.0
           make test-integration
       - name: Test branch's version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,6 +3874,17 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -3894,7 +3905,7 @@ dependencies = [
  "smallvec",
  "thread_local",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -4150,7 +4161,6 @@ dependencies = [
  "chrono",
  "clap",
  "env",
- "env_logger",
  "fallible-iterator 0.3.0",
  "futures",
  "lazy_static",
@@ -4171,6 +4181,8 @@ dependencies = [
  "tiktoken-rs",
  "tokio",
  "tokio-postgres",
+ "tracing",
+ "tracing-log 0.1.4",
  "tracing-subscriber",
  "url",
  "utoipa 4.2.3",

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
  <b>pg_vectorize: a VectorDB on Postgres</b>
 </h1>
 
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%20%7C%2014%20%7C%2015%20%7C%2016%20%7C%2017%20%7C%2018-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+
 A Postgres server and extension that automates the transformation and orchestration of text to embeddings and provides hooks into the most popular LLMs. This allows you to do get up and running and automate maintenance for vector search, full text search, and hybrid search, which enables you to quickly build RAG and search engines on Postgres.
 
 This project relies heavily on the work by [pgvector](https://github.com/pgvector/pgvector) for vector similarity search, [pgmq](https://github.com/pgmq/pgmq) for orchestration in background workers, and [SentenceTransformers](https://huggingface.co/sentence-transformers).
 
 ---
 
-[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%20%7C%2014%20%7C%2015%20%7C%2016%20%7C%2017%20%7C%2018-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 
 **API Documentation**: https://chuckhend.github.io/pg_vectorize/
 
@@ -64,7 +65,12 @@ curl -X POST http://localhost:8080/api/v1/table -d '{
 Search using the HTTP API:
 
 ```bash
-curl -X GET "http://localhost:8080/api/v1/search?job_name=my_job&query=camping%20backpack&limit=1" | jq .
+curl -G \
+  "http://localhost:8080/api/v1/search" \
+  --data-urlencode "job_name=my_job" \
+  --data-urlencode "query=camping backpack" \
+  --data-urlencode "limit=1" \
+  | jq .
 ```
 
 ```json
@@ -79,7 +85,7 @@ curl -X GET "http://localhost:8080/api/v1/search?job_name=my_job&query=camping%2
     "rrf_score": 0.03278688524590164,
     "semantic_rank": 1,
     "similarity_score": 0.6296013593673706,
-    "updated_at": "2025-10-04T14:45:16.152526+00:00"
+    "updated_at": "2025-10-05T00:14:39.220893+00:00"
   }
 ]
 ```

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -327,13 +327,16 @@ BEGIN
         1000 -- default batch size
     );
     FOR batch_result IN SELECT batch FROM vectorize.batch_texts(record_ids, batch_size) LOOP
-        job_messages := array_append(
-            job_messages,
-            jsonb_build_object(
-                'job_name', job_name,
-                'record_ids', batch_result.batch
-            )
-        );
+        -- only append non-null, non-empty batches
+        IF array_length(batch_result.batch, 1) > 0 THEN
+            job_messages := array_append(
+                job_messages,
+                jsonb_build_object(
+                    'job_name', job_name,
+                    'record_ids', batch_result.batch
+                )
+            );
+        END IF;
     END LOOP;
 
     PERFORM pgmq.send_batch(

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -138,7 +138,19 @@ fn default_schedule() -> String {
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct JobMessage {
     pub job_name: String,
+    #[serde(deserialize_with = "null_to_vec")]
     pub record_ids: Vec<String>,
+}
+
+// serde helper to convert JSON null into empty Vec<String>
+use serde::de::Deserializer as SerdeDeserializer;
+
+pub fn null_to_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: SerdeDeserializer<'de>,
+{
+    let opt = Option::<Vec<String>>::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
 }
 
 // schema for every job

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -138,19 +138,7 @@ fn default_schedule() -> String {
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub struct JobMessage {
     pub job_name: String,
-    #[serde(deserialize_with = "null_to_vec")]
     pub record_ids: Vec<String>,
-}
-
-// serde helper to convert JSON null into empty Vec<String>
-use serde::de::Deserializer as SerdeDeserializer;
-
-pub fn null_to_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: SerdeDeserializer<'de>,
-{
-    let opt = Option::<Vec<String>>::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_default())
 }
 
 // schema for every job

--- a/extension/sql/meta.sql
+++ b/extension/sql/meta.sql
@@ -70,13 +70,16 @@ BEGIN
     -- create jobs of size batch_size
     batch_size := current_setting('vectorize.batch_size')::integer;
     FOR batch_result IN SELECT batch FROM vectorize.batch_texts(record_ids, batch_size) LOOP
-        job_messages := array_append(
-            job_messages,
-            jsonb_build_object(
-                'job_name', job_name,
-                'record_ids', batch_result.batch
-            )
-        );
+        -- only append non-null, non-empty batches
+        IF array_length(batch_result.batch, 1) > 0 THEN
+            job_messages := array_append(
+                job_messages,
+                jsonb_build_object(
+                    'job_name', job_name,
+                    'record_ids', batch_result.batch
+                )
+            );
+        END IF;
     END LOOP;
 
     PERFORM pgmq.send_batch(

--- a/proxy/src/embeddings.rs
+++ b/proxy/src/embeddings.rs
@@ -130,21 +130,20 @@ pub fn resolve_prepared_embed_calls(
     parameters: &[String],
 ) -> Result<Vec<EmbedCall>, VectorizeError> {
     for call in &mut embed_calls {
-        if call.is_prepared {
-            if let (Some(query_idx), Some(project_idx)) =
+        if call.is_prepared
+            && let (Some(query_idx), Some(project_idx)) =
                 (call.query_param_index, call.project_param_index)
-            {
-                if query_idx >= parameters.len() || project_idx >= parameters.len() {
-                    return Err(VectorizeError::EmbeddingGenerationFailed(format!(
-                        "Parameter index out of bounds: query_idx={}, project_idx={}, params_len={}",
-                        query_idx,
-                        project_idx,
-                        parameters.len()
-                    )));
-                }
-                call.query = parameters[query_idx].clone();
-                call.project_name = parameters[project_idx].clone();
+        {
+            if query_idx >= parameters.len() || project_idx >= parameters.len() {
+                return Err(VectorizeError::EmbeddingGenerationFailed(format!(
+                    "Parameter index out of bounds: query_idx={}, project_idx={}, params_len={}",
+                    query_idx,
+                    project_idx,
+                    parameters.len()
+                )));
             }
+            call.query = parameters[query_idx].clone();
+            call.project_name = parameters[project_idx].clone();
         }
     }
     Ok(embed_calls)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,7 +26,8 @@ bytes = "1.10.1"
 chrono = {version = "0.4.41", features = ["serde"] }
 clap = { version = "4.0", features = ["derive"] }
 env = "1.0.1"
-env_logger = "0.11"
+tracing = "0.1"
+tracing-log = "0.1"
 fallible-iterator = "0.3.0"
 futures = "0.3.31"
 lazy_static = "1.5.0"

--- a/server/src/errors.rs
+++ b/server/src/errors.rs
@@ -81,7 +81,7 @@ impl ResponseError for ServerError {
             ServerError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
             ServerError::NotFoundError(_) => StatusCode::NOT_FOUND,
             _ => {
-                log::error!("Internal Server Error: {self:?}");
+                tracing::error!("Internal Server Error: {self:?}");
                 StatusCode::INTERNAL_SERVER_ERROR
             }
         }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -52,12 +52,12 @@ async fn main() {
         warn!("Failed to setup job change notifications: {e}");
     }
 
-    // Start the PostgreSQL proxy
-    let proxy_pool = pool.clone();
-    let proxy_cfg = cfg.clone();
-    let proxy_jobmap = Arc::clone(&jobmap);
-    let proxy_cache_pool = cache_pool.clone();
+    // Start the PostgreSQL proxy if enabled
     if cfg.proxy_enabled {
+        let proxy_pool = pool.clone();
+        let proxy_cfg = cfg.clone();
+        let proxy_jobmap = Arc::clone(&jobmap);
+        let proxy_cache_pool = cache_pool.clone();
         tokio::spawn(async move {
             if let Err(e) =
                 start_postgres_proxy(proxy_cfg, proxy_pool, proxy_jobmap, proxy_cache_pool).await

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,5 @@
 use actix_cors::Cors;
 use actix_web::{App, HttpServer, middleware, web};
-use log::{error, info, warn};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
@@ -8,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
+use tracing::{error, info, warn};
 use url::Url;
 
 use vectorize_core::config::Config;
@@ -21,7 +21,8 @@ use vectorize_worker::{WorkerHealthMonitor, start_vectorize_worker_with_monitori
 
 #[actix_web::main]
 async fn main() {
-    env_logger::init();
+    // Initialize tracing subscriber (simple default formatter)
+    tracing_subscriber::fmt().with_target(false).init();
 
     let cfg = Config::from_env();
     let pool = sqlx::postgres::PgPoolOptions::new()
@@ -43,10 +44,10 @@ async fn main() {
         .expect("Failed to initialize project");
 
     // Load initial job cache and setup job change notifications
-    let jobmap = load_initial_job_cache(&pool)
+    let jobcache = load_initial_job_cache(&pool)
         .await
         .expect("Failed to load initial job cache");
-    let jobmap = Arc::new(RwLock::new(jobmap));
+    let jobcache = Arc::new(RwLock::new(jobcache));
 
     if let Err(e) = setup_job_change_notifications(&pool).await {
         warn!("Failed to setup job change notifications: {e}");
@@ -56,11 +57,11 @@ async fn main() {
     if cfg.proxy_enabled {
         let proxy_pool = pool.clone();
         let proxy_cfg = cfg.clone();
-        let proxy_jobmap = Arc::clone(&jobmap);
+        let proxy_jobcache = Arc::clone(&jobcache);
         let proxy_cache_pool = cache_pool.clone();
         tokio::spawn(async move {
             if let Err(e) =
-                start_postgres_proxy(proxy_cfg, proxy_pool, proxy_jobmap, proxy_cache_pool).await
+                start_postgres_proxy(proxy_cfg, proxy_pool, proxy_jobcache, proxy_cache_pool).await
             {
                 error!("Failed to start PostgreSQL proxy: {e}");
             }
@@ -91,7 +92,7 @@ async fn main() {
             .app_data(web::Data::new(cfg.clone()))
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(worker_health_for_routes.clone()))
-            .app_data(web::Data::new(jobmap.clone()))
+            .app_data(web::Data::new(jobcache.clone()))
             .configure(vectorize_server::server::route_config)
             .configure(vectorize_server::routes::health::configure_health_routes)
     })

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -25,14 +25,14 @@ async fn main() {
 
     let cfg = Config::from_env();
     let pool = sqlx::postgres::PgPoolOptions::new()
-        .max_connections(5)
+        .max_connections(cfg.database_pool_max)
         .connect(&cfg.database_url)
         .await
         .expect("unable to connect to postgres");
 
     // Create a separate connection pool for cache refresher
     let cache_pool = sqlx::postgres::PgPoolOptions::new()
-        .max_connections(2)
+        .max_connections(cfg.database_cache_pool_max)
         .connect(&cfg.database_url)
         .await
         .expect("unable to connect to postgres for cache refresher");

--- a/server/src/routes/search.rs
+++ b/server/src/routes/search.rs
@@ -104,7 +104,7 @@ pub async fn search(
         } {
             job_info
         } else {
-            log::warn!(
+            tracing::warn!(
                 "Job not found in cache, querying database for job: {}",
                 payload.job_name
             );

--- a/server/tests/util.rs
+++ b/server/tests/util.rs
@@ -151,7 +151,7 @@ pub mod common {
             .output()
             .unwrap();
         if !output.status.success() {
-            log::error!(
+            tracing::error!(
                 "failed to execute SQL: {}",
                 String::from_utf8_lossy(&output.stderr)
             );

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -5,7 +5,7 @@ pub mod ops;
 pub use health::*;
 
 use crate::executor::poll_job;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use sqlx::PgPool;
 use std::time::Duration;
 use vectorize_core::config::Config;
@@ -75,7 +75,7 @@ async fn start_vectorize_worker_inner(
                 health_monitor.job_processed().await;
             }
             Ok(None) => {
-                info!(
+                debug!(
                     "No messages in queue, waiting for {} seconds",
                     cfg.poll_interval
                 );


### PR DESCRIPTION
- fix clippy warnings
- fix bug where a job would get enqueued when the update trigger would fire but no record change (on conflict)
- changed curl example in readme for readability
- change to`tracing` instead of `env_logger` to help set up structured logging
- configurable connection pool size with a better default